### PR TITLE
Gentoo ebuild and init.rc files

### DIFF
--- a/contrib/gentoo/etc/conf.d/knxd
+++ b/contrib/gentoo/etc/conf.d/knxd
@@ -1,0 +1,2 @@
+KNXD_OPTS="-i usb:"
+PID_FILE="/var/tmp/knxd.pid"

--- a/contrib/gentoo/etc/init.d/knxd
+++ b/contrib/gentoo/etc/init.d/knxd
@@ -1,0 +1,18 @@
+#!/sbin/runscript
+# Copyright 1999-2004 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+start() {
+	ebegin "Starting knxd"
+	start-stop-daemon --start --background --quiet --user nobody:usb --exec /usr/bin/knxd \
+		-- --pid-file=${PID_FILE} ${KNXD_OPTS}
+	eend $?
+}
+
+stop() {
+
+	ebegin "Stopping knxd"
+	start-stop-daemon --stop --quiet --exec /usr/bin/knxd --pidfile "${PID_FILE}"
+	eend $?
+
+}

--- a/contrib/gentoo/sys-apps/knxd/knxd-9999.ebuild
+++ b/contrib/gentoo/sys-apps/knxd/knxd-9999.ebuild
@@ -1,0 +1,58 @@
+# Author: Michael Kefeder
+
+EAPI="2"
+
+inherit eutils autotools git-2
+
+DESCRIPTION="Provides an interface to the EIB / KNX bus (latest git)"
+HOMEPAGE="https://github.com/Makki1/knxd"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS=""
+IUSE="eibd ft12 pei16 tpuart pei16s tpuarts eibnetip eibnetiptunnel eibnetipserver
+usb groupcache java"
+
+DEPEND="dev-libs/pthsem"
+
+EGIT_REPO_URI="https://github.com/Makki1/knxd.git"
+
+src_prepare() {
+    eautoreconf || die "eautotooling failed"
+}
+
+src_configure() {
+#  works for me with the pth tests
+#        --without-pth-test \
+    econf \
+        --enable-onlyeibd \
+        $(use_enable ft12) \
+        $(use_enable pei16) \
+        $(use_enable tpuart) \
+        $(use_enable pei16s) \
+        $(use_enable tpuarts) \
+        $(use_enable eibnetip) \
+        $(use_enable eibnetiptunnel) \
+        $(use_enable eibnetipserver) \
+        $(use_enable usb) \
+        $(use_enable java) \
+        $(use_enable groupcache) || die "econf failed"
+
+}
+
+src_compile() {
+	emake || die "build of knxd failed"
+}
+
+src_install() {
+    emake DESTDIR="${D}" install
+
+    einfo "Installing init-script and config"
+    cd ${S}/contrib/gentoo/etc/
+    exeinto /etc/init.d/
+    doexe init.d/knxd
+
+    insinto /etc/conf.d/
+    doins conf.d/knxd
+
+}


### PR DESCRIPTION
Ebuild to create knxd directly from git-sources. needs sensible udev rules for the usb-hid device (if on is used). a udev rules file should probably be added to contrib/ too?