### PR TITLE
replace malloc.h with stdlib.h

### DIFF
--- a/src/libserver/eibnetserver.cpp
+++ b/src/libserver/eibnetserver.cpp
@@ -20,7 +20,7 @@
 #include "eibnetserver.h"
 #include "emi.h"
 #include "config.h"
-#include <malloc.h>
+#include <stdlib.h>
 
 EIBnetServer::EIBnetServer (const char *multicastaddr, int port, bool Tunnel,
                 bool Route, bool Discover, Layer3 * layer3,


### PR DESCRIPTION
malloc.h is not a standard header. For portability reasons replace it.

This should not have any side effects. 