### PR TITLE
Tell Gentoo what service we provide

### DIFF
--- a/contrib/gentoo/sys-apps/knxd/files/knxd.init
+++ b/contrib/gentoo/sys-apps/knxd/files/knxd.init
@@ -4,6 +4,10 @@
 
 # knxd-@SLOT@
 
+depend() {
+	provide knxd
+}
+
 start() {
 	ebegin "Starting knxd"
 	start-stop-daemon --start --background --quiet --user nobody:usb --exec /usr/bin/knxd \


### PR DESCRIPTION
This allows Gentoo to control the interdependencies between services. Required to start knxd before for example smarthome.py.

Signed-off-by: Stefan Hoffmeister <stefan@hoffmeister.biz>