### PR TITLE
fix Gentoo init script when used with KNXnet/IP

### DIFF
--- a/contrib/gentoo/sys-apps/knxd/files/knxd.init
+++ b/contrib/gentoo/sys-apps/knxd/files/knxd.init
@@ -5,6 +5,7 @@
 # knxd-@SLOT@
 
 depend() {
+	need net
 	provide knxd
 }
 


### PR DESCRIPTION
Start knx daemon after network services to prevent crash on startup when used with KNXnet/IP.

Signed-off-by: Stefan Hoffmeister <stefan@hoffmeister.biz>